### PR TITLE
Es 5.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,42 +6,38 @@ The Combo Analyzer plugin provides with a new analyzer type that combines the ou
 Installation
 -----------
 
-Simply run at the root of your ElasticSearch v0.90+ installation:
+First build the package with maven:
+	
+	mvn package
 
-	bin/plugin -install com.yakaz.elasticsearch.plugins/elasticsearch-analysis-combo/1.5.1
+If you have some problems with tests no passing because of inability to use refleciton on private fields, use:
+	
+	mvn package -DargLine="-Djava.security.manager -Djava.security.policy=allow_all.policy"
 
-This will download the plugin from the Central Maven Repository.
+where contents of allow_all.policy are:
 
-For older versions of ElasticSearch, you can still use v1.2.0 using the longer command:
+	grant {
+		permission java.security.AllPermission;
+	};
 
-	bin/plugin -url http://oss.sonatype.org/content/repositories/releases/com/yakaz/elasticsearch/plugins/elasticsearch-analysis-combo/1.2.0/elasticsearch-analysis-combo-1.2.0.zip install elasticsearch-analysis-combo
+Then run at the root of your ElasticSearch v5.2 installation:
+
+	bin/elasticsearch-plugin install file:<path>/elasticsearch-analysis-combo-5.2.2-SNAPSHOT.zip
+
+Or add to your docker custom build something along the lines:
+
+	COPY elasticsearch-analysis-combo-5.2.2-SNAPSHOT.zip /usr/share/elasticsearch
+	RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install file:/usr/share/elasticsearch/elasticsearch-analysis-combo-5.2.2-SNAPSHOT.zip
+
+For now not uploaded to Central Maven Repository.
 
 In order to declare this plugin as a dependency, add the following to your `pom.xml`:
 
 	<dependency>
 	    <groupId>com.yakaz.elasticsearch.plugins</groupId>
 	    <artifactId>elasticsearch-analysis-combo</artifactId>
-	    <version>1.5.1</version>
+	    <version>5.2.2</version>
 	</dependency>
-
-Version matrix:
-
-    ┌───────────────────────┬──────────────────────────┐
-    │ Combo Analyzer Plugin │ ElasticSearch            │
-    ├───────────────────────┼──────────────────────────┤
-    │ 1.5.x                 │ 1.0.0.RC1 ─► (1.4.3)     │
-    │                       │           ─► (1.3.8)     │
-    ├───────────────────────┼──────────────────────────┤
-    │ 1.4.x                 │ 0.90.3 ─► 0.90.5         │
-    ├───────────────────────┼──────────────────────────┤
-    │ 1.3.x                 │ 0.90.0 ─► 0.90.2         │
-    ├───────────────────────┼──────────────────────────┤
-    │ 1.2.x                 │ 0.19 ─► 0.20             │
-    ├───────────────────────┼──────────────────────────┤
-    │ 1.1.x                 │ 0.19 ─► 0.20             │
-    ├───────────────────────┼──────────────────────────┤
-    │ 1.0.x                 │ 0.19 ─► 0.20             │
-    └───────────────────────┴──────────────────────────┘
 
 Description
 -----------

--- a/pom.xml
+++ b/pom.xml
@@ -89,14 +89,17 @@
         </dependency>
 
         <dependency>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-api</artifactId>
-          <version>2.7</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.7</version>
+            <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>2.7</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.yakaz.elasticsearch.plugins</groupId>
     <artifactId>elasticsearch-analysis-combo</artifactId>
-    <version>2.3.5-SNAPSHOT</version>
+    <version>5.2.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <inceptionYear>2011</inceptionYear>
     <licenses>
@@ -21,7 +21,7 @@
         <developerConnection>scm:git:git@github.com:yakaz/elasticsearch-analysis-combo.git</developerConnection>
         <url>git@github.com:yakaz/elasticsearch-analysis-combo.git</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
     <developers>
         <developer>
             <id>ofavre</id>
@@ -38,9 +38,9 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>2.3.5</elasticsearch.version>
-        <lucene.version>5.5.0</lucene.version>
-        <mvn.java.version>1.7</mvn.java.version>
+        <elasticsearch.version>5.2.2</elasticsearch.version>
+        <lucene.version>6.4.1</lucene.version>
+        <mvn.java.version>1.8</mvn.java.version>
         <!-- Activate the following when running tests against ES 1.4+ -->
         <!--randomizedtesting-runner.version>2.1.10</randomizedtesting-runner.version-->
     </properties>
@@ -62,10 +62,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
+            <groupId>org.elasticsearch.test</groupId>
+            <artifactId>framework</artifactId>
             <version>${elasticsearch.version}</version>
-            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 
@@ -90,11 +89,14 @@
         </dependency>
 
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-            <scope>test</scope>
-            <optional>true</optional>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api</artifactId>
+          <version>2.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.7</version>
         </dependency>
 
         <dependency>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -8,13 +8,13 @@
     <files>
         <file>
             <source>src/main/resources/plugin-descriptor.properties</source>
-            <outputDirectory></outputDirectory>
+            <outputDirectory>elasticsearch</outputDirectory>
             <filtered>true</filtered>
         </file>
     </files>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>elasticsearch</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>

--- a/src/main/java/org/apache/lucene/analysis/ComboAnalyzer.java
+++ b/src/main/java/org/apache/lucene/analysis/ComboAnalyzer.java
@@ -193,7 +193,7 @@ public class ComboAnalyzer extends Analyzer {
         @Override
         public TokenStream getTokenStream() {
             TokenStream ret = createTokenStreams();
-            return deduplication ? new UniqueTokenFilter(ret): ret;
+            return deduplication ? new UniqueTokenFilter(ret, true): ret;
         }
 
         private TokenStream createTokenStreams() {

--- a/src/main/java/org/apache/lucene/analysis/ComboAnalyzerWrapper.java
+++ b/src/main/java/org/apache/lucene/analysis/ComboAnalyzerWrapper.java
@@ -20,6 +20,7 @@
 package org.apache.lucene.analysis;
 
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
@@ -72,7 +73,7 @@ public final class ComboAnalyzerWrapper extends Analyzer {
         for (String subname : sub) {
             NamedAnalyzer analyzer = analyzerResolver.apply(subname);
             if (analyzer == null) {
-                logger.debug("Sub-analyzer \""+subname+"\" not found!");
+                throw new ElasticsearchException("Couldn't find Sub-analyzer [" + subname + "] when initializing [" + name + "] analyzer");
             } else {
                 subAnalyzers.add(analyzer);
             }

--- a/src/main/java/org/apache/lucene/analysis/ComboAnalyzerWrapper.java
+++ b/src/main/java/org/apache/lucene/analysis/ComboAnalyzerWrapper.java
@@ -19,16 +19,14 @@
 
 package org.apache.lucene.analysis;
 
-import org.apache.lucene.util.Version;
-import org.elasticsearch.common.inject.Injector;
-import org.elasticsearch.common.logging.ESLogger;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.analysis.AnalysisService;
+import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 
-import java.io.Reader;
 import java.util.ArrayList;
+import java.util.function.Function;
 
 /**
  * ElasticSearch ComboAnalyzerWrapper wrapper over Lucene ComboAnalyzerWrapper.
@@ -37,27 +35,25 @@ public final class ComboAnalyzerWrapper extends Analyzer {
 
     public static final String NAME = "combo";
 
-    private final ESLogger logger;
+    private final Logger logger;
 
-    private final Injector injector;
     private final Settings settings;
-    private final Version version;
     private final String name;
+    private final Function<String, NamedAnalyzer> analyzerResolver;
 
     private org.apache.lucene.analysis.ComboAnalyzer analyzer;
 
-    public ComboAnalyzerWrapper(Version version, String name, Settings settings, Injector injector) {
+    public ComboAnalyzerWrapper(String name, Settings settings, Function<String, NamedAnalyzer> analyzerResolver) {
         logger = ESLoggerFactory.getLogger(NAME+">"+name);
 
         this.name = name;
 
         // Store parameters for lazy usage
         // See ComboAnalyzerProvider comments to learn why
-        this.injector = injector;
         this.settings = settings;
-        this.version = version;
 
         this.analyzer = null; // must be lazy initialized to get free of the cyclic dependency on AnalysisService
+        this.analyzerResolver = analyzerResolver;
     }
 
     /**
@@ -66,7 +62,6 @@ public final class ComboAnalyzerWrapper extends Analyzer {
     synchronized
     protected void init() {
         if (analyzer != null) return;
-        AnalysisService analysisService = injector.getInstance(AnalysisService.class);
 
         String[] sub = settings.getAsArray("sub_analyzers");
         ArrayList<Analyzer> subAnalyzers = new ArrayList<Analyzer>();
@@ -75,7 +70,7 @@ public final class ComboAnalyzerWrapper extends Analyzer {
         }
 
         for (String subname : sub) {
-            NamedAnalyzer analyzer = analysisService.analyzer(subname);
+            NamedAnalyzer analyzer = analyzerResolver.apply(subname);
             if (analyzer == null) {
                 logger.debug("Sub-analyzer \""+subname+"\" not found!");
             } else {

--- a/src/main/java/org/apache/lucene/util/ReaderCloneFactory.java
+++ b/src/main/java/org/apache/lucene/util/ReaderCloneFactory.java
@@ -17,7 +17,7 @@
 
 package org.apache.lucene.util;
 
-import org.elasticsearch.common.logging.ESLogger;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 
 import java.io.BufferedReader;
@@ -46,7 +46,7 @@ import java.util.WeakHashMap;
  */
 public class ReaderCloneFactory {
 
-    private static final ESLogger logger = ESLoggerFactory.getLogger(ReaderCloneFactory.class.getSimpleName());
+    private static final Logger logger = ESLoggerFactory.getLogger(ReaderCloneFactory.class.getSimpleName());
 
     /**
      * Interface for a utility class, able to unwrap a {@link java.io.Reader}

--- a/src/main/java/org/elasticsearch/index/analysis/ComboAnalyzerProvider.java
+++ b/src/main/java/org/elasticsearch/index/analysis/ComboAnalyzerProvider.java
@@ -20,37 +20,82 @@
 package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.ComboAnalyzerWrapper;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Injector;
-import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.index.Index;
-import org.elasticsearch.index.settings.IndexSettingsService;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.indices.analysis.AnalysisModule;
+import org.elasticsearch.plugin.analysis.combo.AnalysisComboPlugin;
+import org.elasticsearch.plugins.AnalysisPlugin;
+import org.elasticsearch.plugins.PluginsService;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class ComboAnalyzerProvider extends AbstractIndexAnalyzerProvider<ComboAnalyzerWrapper> {
 
-    private final Injector injector;
-    private final Settings settings;
+    private final Environment environment;
+    private final Settings analyzerSettings;
     private final String name;
 
-
-    @Inject 
-	public ComboAnalyzerProvider(Index index, IndexSettingsService indexSettingsService, Environment env, @Assisted String name, @Assisted Settings settings, Injector injector) {
-        super(index, indexSettingsService.getSettings(), name, settings);
+    public ComboAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
+        super(indexSettings, name, settings);
         // Store parameters for delegated usage inside the ComboAnalyzerWrapper itself
         // Sub-analyzer resolution must use the AnalysisService,
         // but as we're a dependency of it (and it's not a Proxy-able interface)
         // we cannot in turn rely on it. Therefore the dependency has to be used lazily.
-        this.injector = injector;
-        this.settings = settings;
+        this.environment = environment;
+        this.analyzerSettings = settings;
         this.name = name;
     }
 
-    @Override public ComboAnalyzerWrapper get() {
+    @Override
+    public ComboAnalyzerWrapper get() {
         // This function is also called during the AnalysisService initialization,
         // hence the following constructor also needs to to perform lazy loading by itself.
-        return new ComboAnalyzerWrapper(version, name, settings, injector);
+        try {
+            IndexAnalyzers indexAnalyzers = getIndexAnalyzers(environment);
+            return new ComboAnalyzerWrapper(name, analyzerSettings, indexAnalyzers::get);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new ElasticsearchException("Exception while getting ComboAnalyzerWrapper from ComboAnalyzerProvider for analyzer with name: " + name + " and with settings: " + analyzerSettings, e);
+        }
     }
-    
+
+    private IndexAnalyzers getIndexAnalyzers(Environment environment) throws IOException {
+
+        final PluginsService pluginsService = new PluginsService(
+            environment.settings(),
+            environment.modulesFile(),
+            environment.pluginsFile(),
+            Collections.singleton(AnalysisComboPlugin.class) // otherwise it will crash when parsing settings of our analysis combo plugin
+        );
+
+        final AnalysisModule analysisModule = new AnalysisModule(
+            environment,
+            pluginsService.filterPlugins(AnalysisPlugin.class)
+        );
+
+        final AnalysisRegistry analysisRegistry = analysisModule.getAnalysisRegistry();
+
+        final Map<String, AnalyzerProvider<?>> analyzerProviderMap = analysisRegistry.buildAnalyzerFactories(indexSettings);
+
+        // we have to filter ComboAnalyzerProvider or we will have infinite recursion
+        Map<String, AnalyzerProvider<?>> analyzerFactories = filterByValue(
+            analyzerProviderMap,
+            e -> !ComboAnalyzerProvider.class.isAssignableFrom(e.getClass())
+        );
+
+        return analysisRegistry.build(indexSettings, analyzerFactories, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    private static <K, V> Map<K, V> filterByValue(Map<K, V> map, Predicate<V> predicate) {
+        return map.entrySet()
+            .stream()
+            .filter(entry -> predicate.test(entry.getValue()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
 }

--- a/src/test/java/org/elasticsearch/index/analysis/TestIntegration.java
+++ b/src/test/java/org/elasticsearch/index/analysis/TestIntegration.java
@@ -11,11 +11,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -29,7 +25,7 @@ public class TestIntegration extends ESIntegTestCase {
     public static final String ANALYZER = "configured_analyzer";
 
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(AnalysisComboPlugin.class);
+        return Collections.singleton(AnalysisComboPlugin.class);
     }
 
     protected Settings nodeSettings(int nodeOrdinal) {


### PR DESCRIPTION
Not sure if this is a correct way to do this. Really had problems creating sub-analyzers, as classes that were used previously are gone now. Using some hackish way of filtering combo plugin itself from settings when asking for other analyzers. Also loading plugins within plugin doesn't seem like a good idea as well.

But it does kinda work. Not sure if all the cases are covered, especially when some other plugin analyzers are used.

I have not  yet checked if the problem with reading multiple times the same input was solved in 5.x.